### PR TITLE
Make attacker model static

### DIFF
--- a/run_attacks.sh
+++ b/run_attacks.sh
@@ -20,7 +20,7 @@ target_models=(
 )
 
 # Static values
-# attacker_model="gpt-4o"
+attacker_model="gpt-4o-mini-2024-07-18"
 target_base_url="https://openrouter.ai/api/v1"
 attacker_base_url="https://openrouter.ai/api/v1"
 
@@ -34,7 +34,7 @@ for tactic in "${jailbreak_tactics[@]}"; do
                 "--jailbreak-tactic \"$tactic\""
                 "--test-case \"$test_case\""
                 "--target-model \"$target_model\""
-                "--attacker-model \"$target_model\""
+                "--attacker-model \"$attacker_model\""
                 "--target-base-url \"$target_base_url\""
                 "--attacker-base-url \"$attacker_base_url\""
             )


### PR DESCRIPTION
I believe we had previously agreed to always use the same attacker model (gpt-4o-mini), I've made the changes in run_attacks.sh to reflect this.

Previously the same model was being used for attacker and target, which if the target was Llama3, was failing to parse the attacker's response into JSON correctly.

With the attacker set to gpt-4o-mini now, there is no parsing issues when the target model is Llama3.